### PR TITLE
Replace `Generator` with `Iterable` to loosen typing constraints

### DIFF
--- a/src/darbia/utils/iterables.py
+++ b/src/darbia/utils/iterables.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable
+from collections.abc import Iterable
 from itertools import islice
 from typing import TypeVar
 
@@ -13,7 +13,7 @@ def enumerate2(
     iterable: Iterable[T],
     start: int = 0,
     step: int = 1,
-) -> Generator[tuple[int, T], None, None]:
+) -> Iterable[tuple[int, T]]:
     """
     Yield items from an iterable with a custom index.
 
@@ -34,7 +34,7 @@ def enumerate2(
 def chunks(
     iterable: Iterable[T],
     size: int,
-) -> Generator[tuple[T, ...], None, None]:
+) -> Iterable[tuple[T, ...]]:
     """
     Yield successive n-sized chunks from iterable.
 

--- a/src/darbia/utils/strings.py
+++ b/src/darbia/utils/strings.py
@@ -6,7 +6,7 @@ import json
 import random
 import re
 import string
-from collections.abc import Generator, Iterable
+from collections.abc import Iterable
 from typing import Any
 
 
@@ -161,7 +161,7 @@ def prefix_zfilled(
     iterable: Iterable,
     sep: str = "-",
     zeroes: int = 3,
-) -> Generator[str, None, None]:
+) -> Iterable[str]:
     """
     Generate a series of formatted strings from an iterable.
 


### PR DESCRIPTION
- https://discord.com/channels/803025117553754132/839142415809249310/1061097726214934640

Replace `Generator` with `Iterable` because `Generator` is too specific and `Iterable` is enough to specify that the value is iterable.